### PR TITLE
Update adapt-config.sh to use IP address instead of hostname

### DIFF
--- a/conf/adapt-config.sh
+++ b/conf/adapt-config.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # calculates the amount of processors and sets the map and reduce tasks accordingly in mapred-site.xml
 line=$(($(grep -c ^processor /proc/cpuinfo)-1))
-hostname=$(cat /etc/hostname)
+hostname=$(grep "$HOSTNAME" /etc/hosts|awk '{print $1}')
 sed -e s/AMOUNT/$line/ -e s/HOSTNAME/$hostname/ /usr/bin/mapred-site-template.xml > /etc/hadoop/conf.pseudo.mr1/mapred-site.xml
 sed s/HOSTNAME/$hostname/ /usr/bin/core-site-template.xml > /etc/hadoop/conf.pseudo.mr1/core-site.xml

--- a/conf/run-hadoop-initial.sh
+++ b/conf/run-hadoop-initial.sh
@@ -11,5 +11,10 @@ sudo /usr/bin/init-hdfs.sh
 # Start MapReduce Service
 for x in `cd /etc/init.d ; ls hadoop-0.20-mapreduce-*` ; do sudo service $x start ; done
 
+#print ip
+
+hostname=$(grep "$HOSTNAME" /etc/hosts|awk '{print $1}')
+echo "Congratulations! Cluster is running on $hostname"
+
 # end with command line
 /bin/bash


### PR DESCRIPTION
Tested with Cloudgene 3. Not sure, if it breaks other dependencies (like imputationserver image?).